### PR TITLE
fix: Connection to return total count

### DIFF
--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -1,0 +1,29 @@
+module Types
+  class BaseConnection < Types::BaseObject
+    # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
+    include GraphQL::Types::Relay::ConnectionBehaviors
+
+    field :total_count, Integer, "Total # of objects returned from this Plural Query", null: false
+    def total_count
+      object.nodes&.count
+    end
+
+    field :total_page_count, Integer, "Total # of pages, based on total count and pagesize", null: false
+    def total_page_count
+      return 1 unless object.nodes&.count&.positive?
+      # get total count and create array with total count as first item
+      my_total_count = object.nodes&.count
+      possible_page_sizes = [my_total_count]
+
+      # add first and last argument counts to the array if they exist
+      possible_page_sizes.push(object.arguments[:first]) if object.arguments[:first]
+      possible_page_sizes.push(object.arguments[:last]) if object.arguments[:last]
+
+      # get the smallest of the array items
+      actual_page_size = possible_page_sizes.min
+
+      # return the total_count divided by the page size, rounded up
+      (my_total_count / actual_page_size.to_f).ceil
+    end
+  end
+end

--- a/lib/generators/cm_graphql/add_graphql_generator.rb
+++ b/lib/generators/cm_graphql/add_graphql_generator.rb
@@ -8,6 +8,7 @@ module CmGraphql
       def add_graphql
         generate 'graphql:install'
         template 'graphql_schema.rb', "app/graphql/#{Rails.application.class.module_parent_name.underscore}_schema.rb"
+        copy_file 'base_connection.rb', 'app/graphql/types/base_connection.rb'
         gsub_file 'app/controllers/graphql_controller.rb', '# protect_from_forgery with: :null_session', 'protect_from_forgery with: :null_session'
       end
     end

--- a/lib/generators/cm_graphql/templates/base_connection.rb
+++ b/lib/generators/cm_graphql/templates/base_connection.rb
@@ -1,0 +1,29 @@
+module Types
+  class BaseConnection < Types::BaseObject
+    # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
+    include GraphQL::Types::Relay::ConnectionBehaviors
+
+    field :total_count, Integer, "Total # of objects returned from this Plural Query", null: false
+    def total_count
+      object.nodes&.count
+    end
+
+    field :total_page_count, Integer, "Total # of pages, based on total count and pagesize", null: false
+    def total_page_count
+      return 1 unless object.nodes&.count&.positive?
+      # get total count and create array with total count as first item
+      my_total_count = object.nodes&.count
+      possible_page_sizes = [my_total_count]
+
+      # add first and last argument counts to the array if they exist
+      possible_page_sizes.push(object.arguments[:first]) if object.arguments[:first]
+      possible_page_sizes.push(object.arguments[:last]) if object.arguments[:last]
+
+      # get the smallest of the array items
+      actual_page_size = possible_page_sizes.min
+
+      # return the total_count divided by the page size, rounded up
+      (my_total_count / actual_page_size.to_f).ceil
+    end
+  end
+end


### PR DESCRIPTION
## What does this change do?
- Connection type to return total_count key by default.


## Why is this change needed?
- We need to add manually total_count key to each project. 


## How was testing done?
- Ran the generator in local and it copied the file.
