### PR TITLE
Image URL with resolution argument support

### DIFF
--- a/app/graphql/types/inputs/image_resolution.rb
+++ b/app/graphql/types/inputs/image_resolution.rb
@@ -1,0 +1,12 @@
+module Types
+  module Inputs
+    class ImageResolution < Base::Filter
+      graphql_name 'ImageResolution'
+
+      description 'Additional attributes needed for Image Resolution'
+
+      argument :width,         Integer,  nil,  required: true
+      argument :height,        Integer,  nil,  required: true
+    end
+  end
+end

--- a/app/graphql/types/objects/base/attachment_type.rb
+++ b/app/graphql/types/objects/base/attachment_type.rb
@@ -35,7 +35,7 @@ module Types::Objects::Base
     end
 
     def resize_image(width, height, attachment)
-      if width.present? && height.present? && attachment.attached?
+      if width.present? && height.present? && (attachment.attached? && attachment.content_type.include?('image'))
         attachment.variant(resize_to_fill: [width, height])
       else
         attachment

--- a/app/graphql/types/objects/base/attachment_type.rb
+++ b/app/graphql/types/objects/base/attachment_type.rb
@@ -2,7 +2,9 @@ module Types::Objects::Base
   class AttachmentType < Types::BaseObject
     field :id,          Int,      nil, null: false
     field :filename,    String,   nil, null: false
-    field :url,         String,   nil, null: false
+    field :url,         String,   nil, null: false do
+      argument :resolution, Types::Inputs::ImageResolution, required: false, default_value: nil
+    end
     field :base64,      String,   nil, null: false
 
     def id
@@ -21,13 +23,22 @@ module Types::Objects::Base
       end
     end
 
-    def url
-      if object.class.eql?(ActiveStorage::Variant)
-        Rails.application.routes.url_helpers.rails_representation_url(object)
-      elsif defined?(object.service_url)
-        object.service_url
+    def url(resolution:)
+      resized_image = resize_image(resolution&.width, resolution&.height, object)
+      if resized_image.class.eql?(ActiveStorage::Variant) || resized_image.class.eql?(ActiveStorage::VariantWithRecord)
+        Rails.application.routes.url_helpers.rails_representation_url(resized_image)
+      elsif defined?(resized_image.service_url)
+        resized_image.service_url
       else
-        object.url
+        resized_image.url
+      end
+    end
+
+    def resize_image(width, height, attachment)
+      if width.present? && height.present? && attachment.attached?
+        attachment.variant(resize_to_fill: [width, height])
+      else
+        attachment
       end
     end
 


### PR DESCRIPTION
## What does this change do?
- We can resize the image by passing width and height


## Why is this change needed?
- It is built custom on each application, moving it to cm-graphql


## How were the changes done?
- Resolution input argument added to field `url`
- Resized if the resolution is passed

## How was testing done?
- In development with DRE application
